### PR TITLE
Use pip3 install -r requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,22 +34,14 @@ This repo contains scripts, instructions to manage your own selfie a day project
 ### Run
 
 * Clone/download this repo
-
 * Download [shape_predictor_68_face_landmarks.dat](https://sourceforge.net/projects/dclib/files/dlib/v18.10/shape_predictor_68_face_landmarks.dat.bz2) and place it in the cloned repo folder
-
 * Install the following dependencies by ```pip3 install -r requirements.txt```
   ```bash
   $ pip3 install wheel scipy exifread python-resize-image dlib
-  ```
-  
-  
-  
+  ```  
 * Copy pictures to `input` folder
-
 * Run `make-input.py`. This'll resize every images in `input` folder to a square which [solves this](https://github.com/matthewearl/photo-a-day-aligner/issues/1)
-
 * Edit `pada.conf` according to your need
-
 * Run :
   ```python3 pada.py align```
 

--- a/README.md
+++ b/README.md
@@ -34,17 +34,22 @@ This repo contains scripts, instructions to manage your own selfie a day project
 ### Run
 
 * Clone/download this repo
+
 * Download [shape_predictor_68_face_landmarks.dat](https://sourceforge.net/projects/dclib/files/dlib/v18.10/shape_predictor_68_face_landmarks.dat.bz2) and place it in the cloned repo folder
-* Install dependencies :
+
+* Install the following dependencies by ```pip3 install -r requirements.txt```
+  ```bash
+  $ pip3 install wheel scipy exifread python-resize-image dlib
   ```
-  pip3 install wheel
-  pip3 install dlib
-  pip3 install scipy
-  pip3 install exifread python-resize-image
-  ```
+  
+  
+  
 * Copy pictures to `input` folder
+
 * Run `make-input.py`. This'll resize every images in `input` folder to a square which [solves this](https://github.com/matthewearl/photo-a-day-aligner/issues/1)
+
 * Edit `pada.conf` according to your need
+
 * Run :
   ```python3 pada.py align```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+wheel>=0.33.6
+dlib>=19.18.0
+ExifRead>=2.1.2
+python-resize-image>=1.1.19
+scipy>=1.3.1


### PR DESCRIPTION
It is better to use ``requirements.txt`` to install python dependencies. 
You can use ``pip3 install -r requirements.txt`` to install them. Also ``pip3 freeze > requirements.txt`` can create the requirements.txt with the dependencies(if you use virtualenv) .